### PR TITLE
deps: Bump pytest from 7.0.0 to 8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ requests>=2.28.0
 # cryptography>=40.0.0
 
 # Development and testing
-pytest>=7.0.0
+pytest>=8.0.0
 pytest-asyncio>=0.21.0


### PR DESCRIPTION
Bumps pytest from 7.0.0 to 8.0.0 for improved testing capabilities and security updates.