### PR TITLE
deps: Bump pyyaml from 6.0 to 6.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Note: In production, install only required packages based on your needs
 
 # Basic Python utilities
-pyyaml>=6.0
+pyyaml>=6.0.2
 python-dotenv>=1.0.0
 requests>=2.28.0
 


### PR DESCRIPTION
Bumps pyyaml from 6.0 to 6.0.2.

**Release notes**
*Sourced from [PyYAML releases](https://github.com/yaml/pyyaml/releases).*

**Changelog**
*Sourced from [PyYAML changelog](https://github.com/yaml/pyyaml/blob/main/CHANGES).*

---
- **dependency-name**: pyyaml
- **dependency-type**: direct:production  
- **update-type**: version-update:semver-patch

Signed-off-by: dependabot[bot] <support@github.com>